### PR TITLE
Fixed the assembly reference for: System.IO.Abstractions

### DIFF
--- a/Cantos.Tests/Cantos.Tests.fsproj
+++ b/Cantos.Tests/Cantos.Tests.fsproj
@@ -40,7 +40,8 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.IO.Abstractions, Version=1.4.0.35, Culture=neutral, PublicKeyToken=d480b5b72fb413da">
+    <Reference Include="System.IO.Abstractions">
+      <HintPath>..\packages\System.IO.Abstractions.1.4.0.35\lib\net35\System.IO.Abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Abstractions.TestingHelpers">


### PR DESCRIPTION
Fixed the assembly reference for: System.IO.Abstractions.1.4.0.35 was not pointing at the packages location.
